### PR TITLE
Add qubits validation to resourc-estimator

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.3.1
+==========================
+
+* Add device-specific qubit limits
+* Display maximum qubit count hint in the UI for each device
+
 Version 0.3.0
 ============
 

--- a/src/utils/ResourceEstimatorModel.js
+++ b/src/utils/ResourceEstimatorModel.js
@@ -8,6 +8,7 @@
 const DEVICE_PARAMS = {
 	helmi: {
 		name: 'Helmi',
+		max_qubits: 5,
 		intercept: 2.361885,
 		terms: [
 			{type: 'interaction', variables: ['batches', 'kshots'], coefficient: 0.432804},
@@ -27,6 +28,7 @@ const DEVICE_PARAMS = {
 	},
 	'vtt-q50': {
 		name: 'VTT Q50',
+		max_qubits: 54,
 		// Model: Log-transform (captures multiplicative structure)
 		logTransform: true,  // Model trained on log(y), must apply exp()
 		epsilon: 0.001000,

--- a/test_js_python_consistency.js
+++ b/test_js_python_consistency.js
@@ -1,5 +1,22 @@
 // Test JavaScript model consistency with Python
-import { calculateQPUSeconds } from './src/utils/ResourceEstimatorModel.js';
+import { calculateQPUSeconds, DEVICE_PARAMS } from './src/utils/ResourceEstimatorModel.js';
+
+// First, verify device configurations
+console.log('Verifying device configurations...');
+console.log('Helmi max_qubits:', DEVICE_PARAMS.helmi.max_qubits);
+console.log('VTT Q50 max_qubits:', DEVICE_PARAMS['vtt-q50'].max_qubits);
+
+if (DEVICE_PARAMS.helmi.max_qubits !== 5) {
+	console.error('❌ Helmi should have max_qubits = 5');
+	process.exit(1);
+}
+
+if (DEVICE_PARAMS['vtt-q50'].max_qubits !== 54) {
+	console.error('❌ VTT Q50 should have max_qubits = 54');
+	process.exit(1);
+}
+
+console.log('✅ Device configurations are correct\n');
 
 // Test cases from CSV (verify JavaScript matches Python, not necessarily actual values)
 // The goal is to ensure JS and Python produce identical predictions


### PR DESCRIPTION
The device in the resource estimator currently allows for more qubits than is possible on the device. E.g Helmi has 5 qubits but allows input of 50 qubits and VTT Q50 has 54 qubits but allows input of 500 qubits. Restrictions are added to prevent the user from inputting incorrect number of qubits. 